### PR TITLE
Update titles for Blog and Downloads pages

### DIFF
--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -20,7 +20,7 @@ export default function Blog() {
   return (
     <div className="container flex flex-col root home-page" style={{fontFamily: 'Inter', maxWidth: '1024px'}}>
       <Head>
-        <title>downloads</title>
+        <title>Blog</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <GlobalStyle />

--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -8,7 +8,7 @@ export default function Downloads() {
   return (
     <div className="container flex flex-col root home-page" style={{fontFamily: 'Inter', maxWidth: '1024px'}}>
       <Head>
-        <title>downloads</title>
+        <title>Downloads</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <GlobalStyle />


### PR DESCRIPTION
Fixed wrong title being used on the Blogs page, and lowercase `d` on the Downloads page.

Super-minor issues, I know, but just something that caught my eye 😄 