### PR TITLE
update: linux download naming changes

### DIFF
--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { IconBrandApple, IconBrandWindows, IconBrandUbuntu, IconBrandChrome, IconBrandDocker, IconDeviceDesktop } from "@tabler/icons";
+import { IconBrandApple, IconBrandWindows, IconBrandUbuntu } from "@tabler/icons";
 import Navbar from 'components/Navbar';
 import Footer from 'components/Footer';
 import GlobalStyle from '../globalStyles';
@@ -80,7 +80,7 @@ export default function Downloads() {
 
               <tr className="bg-white border-b">
                 <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                  <IconBrandUbuntu className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Ubuntu Linux</span>
+                  <IconBrandUbuntu className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Linux (deb)</span>
                 </td>
                 <td className="py-3 pl-6 pr-10">
                 <a href="https://github.com/usebruno/bruno/releases/download/v0.22.1/bruno_0.22.1_amd64_linux.deb" target="_blank" rel="noreferrer" className='link'>
@@ -91,7 +91,7 @@ export default function Downloads() {
 
               <tr className="bg-white border-b">
                 <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                  <IconDeviceDesktop className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Linux</span>
+                  <IconBrandUbuntu className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Linux (AppImage)</span>
                 </td>
                 <td className="py-3 pl-6 pr-10">
                 <a href="https://github.com/usebruno/bruno/releases/download/v0.22.1/bruno_0.22.1_x86_64_linux.AppImage" target="_blank" rel="noreferrer" className='link'>


### PR DESCRIPTION
I think it would be better to specify deb or AppImage  type in the downloads page for Linux.
and since deb packages works on other Linux distros other than Ubuntu, I think having name "Linux" is better instead of "Ubuntu Linux" 


changes:

- Ubuntu Linux => Linux (deb)
- Linux => Linux (AppImage)
- Made both Linux download Icons same

![image](https://github.com/usebruno/bruno-website/assets/76877078/101a9a9d-4b3f-4741-97cc-0494c2ccbe82)
