### PR TITLE
Dynamically render download page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 Website for usebruno.com built using NextJS
 
 ### Requirements
-* Node v14
+* Node v18
 * Npm v8
 
 ### Workflow

--- a/src/pages/bru.js
+++ b/src/pages/bru.js
@@ -4,7 +4,7 @@ import Navbar from 'components/Navbar';
 import Footer from 'components/Footer';
 import GlobalStyle from '../globalStyles';
 
-export default function Downloads() {
+export default function Bru() {
   return (
     <div className="container flex flex-col root home-page" style={{fontFamily: 'Inter', maxWidth: '1024px'}}>
       <Head>

--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -7,10 +7,20 @@ import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import 'react-tabs/style/react-tabs.css';
 import GlobalStyle from '../globalStyles';
 
-export default function Downloads() {
-  const latestVersion = '0.25.0';
-  const releaseDate = 'Oct 16, 2023';
+export async function getStaticProps() {
+  const res = await fetch('https://api.github.com/repos/usebruno/bruno/releases/latest')
+  const data = await res.json()
 
+  return {
+    props: {
+      latestVersion: data.tag_name.replace('v', ''),
+      releaseDate: new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(data.created_at)),
+    },
+    revalidate: 60*60, // refresh every hour
+  }
+}
+
+export default function Downloads({ latestVersion, releaseDate }) {
   return (
     <div className="container flex flex-col root downloads-page" style={{fontFamily: 'Inter', maxWidth: '1024px'}}>
       <Head>
@@ -67,7 +77,7 @@ export default function Downloads() {
                       <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac x64</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href="https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_x64_mac.dmg" target="_blank" rel="noreferrer" className='link'>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.dmg`} target="_blank" rel="noreferrer" className='link'>
                       Download
                     </a>
                     </td>
@@ -78,7 +88,7 @@ export default function Downloads() {
                       <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac x64 (Portable)</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href="https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_x64_mac.zip" target="_blank" rel="noreferrer" className='link'>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.zip`} target="_blank" rel="noreferrer" className='link'>
                       Download
                     </a>
                     </td>
@@ -89,7 +99,7 @@ export default function Downloads() {
                       <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac Apple Silicon</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href="https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_arm64_mac.dmg" target="_blank" rel="noreferrer" className='link'>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.dmg`} target="_blank" rel="noreferrer" className='link'>
                       Download
                     </a>
                     </td>
@@ -100,7 +110,7 @@ export default function Downloads() {
                       <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac Apple Silicon (Portable)</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href="https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_arm64_mac.zip" target="_blank" rel="noreferrer" className='link'>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.zip`} target="_blank" rel="noreferrer" className='link'>
                       Download
                     </a>
                     </td>
@@ -130,7 +140,7 @@ export default function Downloads() {
                       <IconBrandUbuntu className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Ubuntu / Debian</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href="https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_amd64_linux.deb" target="_blank" rel="noreferrer" className='link'>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_amd64_linux.deb`} target="_blank" rel="noreferrer" className='link'>
                       Download
                     </a>
                     </td>
@@ -141,7 +151,7 @@ export default function Downloads() {
                       <IconDeviceDesktop className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Linux AppImage</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href="https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_x86_64_linux.AppImage" target="_blank" rel="noreferrer" className='link'>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x86_64_linux.AppImage`} target="_blank" rel="noreferrer" className='link'>
                       Download
                     </a>
                     </td>
@@ -195,7 +205,7 @@ export default function Downloads() {
                       <IconBrandWindows className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Windows x64</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href="https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_x64_win.exe" target="_blank" rel="noreferrer" className='link'>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.exe`} target="_blank" rel="noreferrer" className='link'>
                       Download
                     </a>
                     </td>
@@ -206,7 +216,7 @@ export default function Downloads() {
                       <IconBrandWindows className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Windows x64 (Portable)</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href="https://github.com/usebruno/bruno/releases/download/v0.25.0/bruno_0.25.0_x64_win.zip" target="_blank" rel="noreferrer" className='link'>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.zip`} target="_blank" rel="noreferrer" className='link'>
                       Download
                     </a>
                     </td>


### PR DESCRIPTION
Instead of hard-coded information, the download page now fetch latest release information from GitHub directly.

Will fix https://github.com/usebruno/bruno/issues/543