### PR TITLE
GitHub workflow should target main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CI: true


### PR DESCRIPTION
I used `master` by default, but that repo is using `main` branch instead. My mistake.