### PR TITLE
feat(#19): Default to user's OS on Downloads page

### DIFF
--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -6,6 +6,7 @@ import Footer from 'components/Footer';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import 'react-tabs/style/react-tabs.css';
 import GlobalStyle from '../globalStyles';
+import {useEffect, useState} from "react";
 
 export async function getStaticProps() {
   const res = await fetch('https://api.github.com/repos/usebruno/bruno/releases/latest')
@@ -23,6 +24,13 @@ export async function getStaticProps() {
 }
 
 export default function Downloads({ latestVersion, releaseDate }) {
+  let [tabIndex, setTabIndex] = useState(0);
+
+  useEffect(() => {
+    if (navigator.userAgent.toLowerCase().includes("linux")) setTabIndex(1);
+    if (navigator.userAgent.toLowerCase().includes("windows")) setTabIndex(2);
+  }, [])
+
   return (
     <div className="container flex flex-col root downloads-page" style={{fontFamily: 'Inter', maxWidth: '1024px'}}>
       <Head>
@@ -57,7 +65,7 @@ export default function Downloads({ latestVersion, releaseDate }) {
           </a>
         </div>
 
-        <Tabs className="mt-2">
+        <Tabs selectedIndex={tabIndex} onSelect={index => setTabIndex(index)} className="mt-2">
           <TabList className="flex mt-4 space-x-4">
             <Tab className="px-4 py-2 bg-gray-200 flex items-center rounded-md cursor-pointer hover:bg-gray-300">
               <IconBrandApple className="text-gray-500 mr-2 icon" size={24} strokeWidth={2}/>Mac


### PR DESCRIPTION
Closes #19 

Now it'll automatically select/highlight the appropriate tab according to the user's OS

|Before|After|
|-------|------|
|<video src="https://github.com/usebruno/bruno-website/assets/30027205/fb4b0079-c4d3-4eb1-922a-cb6e46f830af"></video>|<video src="https://github.com/usebruno/bruno-website/assets/30027205/52ce01e4-5e2f-4e6a-9a9a-432de2c641fb"></video>|
|<video src="https://github.com/usebruno/bruno-website/assets/30027205/194ccb0f-289d-48e9-8e87-7910aec80db5"></video>|<video src="https://github.com/usebruno/bruno-website/assets/30027205/bb3d284a-13e4-4a93-93fa-54b6b7d5e695"></video>|
