### PR TITLE
Fix grammar with its and it apostrophe s

### DIFF
--- a/posts/announcing-version-1.md
+++ b/posts/announcing-version-1.md
@@ -41,7 +41,7 @@ As of this writing, we have over **7k stars**.
 
 ## Monthly active users
 
-Its not just stars, we also massive growth of people who use bruno. For 23 months, we had around 100-200 people who used Bruno every month. But in the Oct 2023, we had **over 20,000 people** use Bruno.
+It's not just stars, we also massive growth of people who use bruno. For 23 months, we had around 100-200 people who used Bruno every month. But in the Oct 2023, we had **over 20,000 people** use Bruno.
 
 ![monthly users oct 2023](/images/monthly-users-oct-2023.png)
 
@@ -51,13 +51,13 @@ Bruno's community has experienced remarkable growth, seemingly out of nowhere. I
 
 And there are still over **50 pull requests** waiting to be [merged](https://github.com/usebruno/bruno/pulls).
 
-This rapid pace of growth is also a testament to the quality and robustness of our codebase, which allowed us to readily accept these contributions and scale up with confidence. 
+This rapid pace of growth is also a testament to the quality and robustness of our codebase, which allowed us to readily accept these contributions and scale up with confidence.
 
 We can't thank enough 💛 to all the people who contributed to Bruno and helped us get here.
 
 ## Reaction
 
-It has been exhilarating to see the reaction of the community. We are not an alternative, but a new way of working with API Collections. We are re-inventing the Api Client. 
+It has been exhilarating to see the reaction of the community. We are not an alternative, but a new way of working with API Collections. We are re-inventing the Api Client.
 
 You can check out the testimonials on our landing page. If you'd like to share your experience with Bruno, please [write here](https://github.com/usebruno/bruno/discussions/343)
 
@@ -86,7 +86,7 @@ Here is Bruno. The prince who will be fetching your Api's.
 
 I have been documenting the journey of Bruno [publicly here](https://github.com/usebruno/bruno/discussions/269). You can checkout our [roadmap](https://github.com/usebruno/bruno/discussions/384)
 
-Our mission is to 
+Our mission is to
 
 * Build the most simple, beautiful, and powerful API client that developers love.
 * And uphold these principles
@@ -102,5 +102,3 @@ As far as how we build a sustainable business, we are still in the process of fi
 We are here for the long run. We want to give developers what they have always wanted. A beautiful curl UI.
 
 Godspeed 🖖 🐶 💛
-
-

--- a/posts/bootstrapping.md
+++ b/posts/bootstrapping.md
@@ -11,7 +11,7 @@ This is in some way a personal post and covers some of my worldviews and my thou
 * I will be working full-time on Bruno from Jan 2024.
 * Despite VC interest (8 VCs reached out in last 2 months), I have chosen not to explore raising money for Bruno. Reasons being:
   - Would like to grow slowly, preserve full liberty and freedom over the product direction.
-  - Have confidence in building a profitable enterprise through Golden Edition purchases as well as building ancillary products around Bruno. 
+  - Have confidence in building a profitable enterprise through Golden Edition purchases as well as building ancillary products around Bruno.
 * Will be setting up a monthly community call to discuss the product, roadmap, anything and everything related to Bruno (first wed of every month at 5 PM GMT.)
 
 ### Business ?
@@ -20,7 +20,7 @@ In the past, my vision for Bruno didn't involve establishing a company or hiring
 Bruno's exponential growth has surpassed those initial plans. Currently, there are over 400 pending issues and 80 pull requests awaiting review, despite merging 250 PRs in the last two months alone (averaging 4 merges per day). Balancing this part-time alongside my day job as a tech lead is no longer feasible.
 
 Here are some of the highlights that happened in the last 2 months compared to the previous two years:
-* Grew from 500 to ➡️ 25,000 monthly active users 
+* Grew from 500 to ➡️ 25,000 monthly active users
 * Github stars skyrocketed from 500 ➡️ 9,000
 * Launched [version 1.0.0](https://www.usebruno.com/blog/announcing-version-1)
 * Presented Bruno at [India Foss 3.0](https://www.youtube.com/watch?v=7bSMFpbcPiY)
@@ -29,16 +29,16 @@ Here are some of the highlights that happened in the last 2 months compared to t
 * VC inbound interest to explore increased from 2 ➡️ 8
 * GitHub Sponsorships revenue grew from 0$ ➡️ 40$/month
 
-### Thoughts on VC funding 
+### Thoughts on VC funding
 I would like to first clarify that I am not against VC funding. It's the reason why many of us in the industry have well paying jobs in swanky offices. They inject capital and help push the ecosystem forward.
 
-When it comes to Bruno, my stance on VC funding remains the same. An API client is not venture scale. 
+When it comes to Bruno, my stance on VC funding remains the same. An API client is not venture scale.
 
-Some friends and colleagues are baffled on why I would reject an opportunity to explore funding when there is inbound interest from VC's. The irony is that - before Sep 2023, I would have accepted funding in the blink of an eye; but now despite inbound interest, I am no longer interested. 
+Some friends and colleagues are baffled on why I would reject an opportunity to explore funding when there is inbound interest from VC's. The irony is that - before Sep 2023, I would have accepted funding in the blink of an eye; but now despite inbound interest, I am no longer interested.
 
 Looking back, I had nothing. Just an innovative api client with little to no visibility. That may be the reason that would have accept taken VC funding in the past. Just to "matter", to be "heard", to gain some visibility.
 
-Its not the case anymore today. We have a growing community and contributors who help make Bruno better.
+It's not the case anymore today. We have a growing community and contributors who help make Bruno better.
 We have feedback where people literally say - "I love Bruno". What more do I need as a creator (as long as I figure out a way to make a living out of it)?
 
 ### Perils of VC funding
@@ -53,7 +53,7 @@ Just like 99.99% of you, I am motivated by money and would like have nice things
 
 Most people who deny and say that they start a company to change the world are lying. There is always an element of self-interest. If they still say that they are not motivated by money, ask them to hand over half of their shares to a non-profit. They won't. Very few people get to a place where they are no longer motivated by money.
 
-The business model for Bruno is simple. Its just aligning the incentives.
+The business model for Bruno is simple. It's just aligning the incentives.
   * Build and maintain most of the features as opensource (most things a developer needs)
   * Offer select features under the paid plans (features that a business needs)
   * Foster a thriving community of contributors and users
@@ -64,7 +64,7 @@ The business model for Bruno is simple. Its just aligning the incentives.
 ### Rebellion
 Bruno, at its core is a [rebellion](/manifesto) against the status quo of the API client ecosystem.
 
-Its quite common these days to raise money and go big when your opensource project gains traction and a certain number of github stars. Many api clients have done that.
+It's quite common these days to raise money and go big when your opensource project gains traction and a certain number of github stars. Many api clients have done that.
 
 The spirit of rebellion (challenging the status quo, rethinking from first principles) continues in the  choice to bootstrap Bruno. Explicitly choosing to not raise money and grow slowly.
 

--- a/src/pages/compare/bruno-vs-postman.js
+++ b/src/pages/compare/bruno-vs-postman.js
@@ -60,7 +60,7 @@ export default function CompareBrunoVsPostman() {
           Online vs Offline
         </h2>
         <div className='mt-6'>
-          Postman requires you to be <a className='link' href="https://community.postman.com/t/working-in-offline-mode/20174/37" target="_blank" rel="noreferrer">online</a> to use it. 
+          Postman requires you to be <a className='link' href="https://community.postman.com/t/working-in-offline-mode/20174/37" target="_blank" rel="noreferrer">online</a> to use it.
 
           <div className='mt-4'>
             Bruno is a desktop app, and is made for offline use.
@@ -125,7 +125,7 @@ export default function CompareBrunoVsPostman() {
         </div>
 
         <h1 className="mt-8 text-2xl font-semibold leading-tight w-full">
-          Its time
+          It's time
         </h1>
         <div className='mt-6'>
           <Link href="/downloads" legacyBehavior>


### PR DESCRIPTION
Fixes for `its` and `it's`.

From ChatGPT:

> 
> 
> "its" and "it's" are two commonly confused words in English:
> 
>     "Its": This is a possessive pronoun used to indicate something that belongs to or is associated with a thing, animal, or non-human entity. It denotes possession without using an apostrophe. For example:
>         "The dog wagged its tail."
>         "The tree shed its leaves in autumn."
> 
>     "It's": This is a contraction, a shortened form of "it is" or "it has." The apostrophe in "it's" represents the omitted letters. For example:
>         "It's a beautiful day." (It is a beautiful day.)
>         "It's been a long time." (It has been a long time.)
> 
> Remember:
> 
>     If you can replace the word with "it is" or "it has," then use "it's."
>     If you're denoting possession, use "its" without an apostrophe.
> 
> Confusion often arises because apostrophes in English typically denote possession, but with "its," the possessive form doesn't use an apostrophe.