### PR TITLE
Resolved non-responsive layout for Apt installation steps on Downloads page 

### DIFF
--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -1,44 +1,30 @@
-import Head from "next/head";
-import Link from "next/link";
-import {
-  IconBrandApple,
-  IconBrandWindows,
-  IconBrandUbuntu,
-  IconDeviceDesktop,
-} from "@tabler/icons";
-import Navbar from "components/Navbar";
-import Footer from "components/Footer";
-import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
-import "react-tabs/style/react-tabs.css";
-import GlobalStyle from "../globalStyles";
+import Head from 'next/head';
+import Link from 'next/link';
+import { IconBrandApple, IconBrandWindows, IconBrandUbuntu, IconDeviceDesktop } from "@tabler/icons";
+import Navbar from 'components/Navbar';
+import Footer from 'components/Footer';
+import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
+import 'react-tabs/style/react-tabs.css';
+import GlobalStyle from '../globalStyles';
 
 export async function getStaticProps() {
-  const res = await fetch(
-    "https://api.github.com/repos/usebruno/bruno/releases/latest"
-  );
-  const data = await res.json();
+  const res = await fetch('https://api.github.com/repos/usebruno/bruno/releases/latest')
+  const data = await res.json()
 
   return {
     props: {
-      latestVersion: "1.5.1",
+      latestVersion: '1.5.1',
       // disabling this for now
       // latestVersion: data.tag_name.replace('v', ''),
-      releaseDate: new Intl.DateTimeFormat("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-      }).format(new Date(data.created_at)),
+      releaseDate: new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(data.created_at)),
     },
-    revalidate: 60 * 15, // refresh every 15 minutes
-  };
+    revalidate: 60*15, // refresh every 15 minutes
+  }
 }
 
 export default function Downloads({ latestVersion, releaseDate }) {
   return (
-    <div
-      className="container flex flex-col root downloads-page"
-      style={{ fontFamily: "Inter", maxWidth: "1024px" }}
-    >
+    <div className="container flex flex-col root downloads-page" style={{fontFamily: 'Inter', maxWidth: '1024px'}}>
       <Head>
         <title>Downloads</title>
         <link rel="icon" href="/favicon.ico" />
@@ -54,21 +40,13 @@ export default function Downloads({ latestVersion, releaseDate }) {
 
         <div className="mt-4">
           <p className="text-gray-500 text-sm">
-            Latest Version:{" "}
-            <Link
-              href={`https://github.com/usebruno/bruno/releases/tag/v${latestVersion}`}
-              className="link"
-              target="_blank"
-            >
-              {latestVersion}
-            </Link>
+            Latest Version: <Link href={`https://github.com/usebruno/bruno/releases/tag/v${latestVersion}`} className='link' target="_blank">{latestVersion}</Link>
           </p>
           <p className="text-gray-500 text-sm">Release Date: {releaseDate}</p>
         </div>
 
-        <div className="mt-4 text-sm">
-          If you like Bruno and want to support our opensource work, consider
-          sponsoring us via
+        <div className='mt-4 text-sm'>
+          If you like Bruno and want to support our opensource work, consider sponsoring us via 
           <a
             href="https://github.com/sponsors/helloanoop"
             target="_blank"
@@ -82,36 +60,19 @@ export default function Downloads({ latestVersion, releaseDate }) {
         <Tabs className="mt-2">
           <TabList className="flex mt-4 space-x-4">
             <Tab className="px-4 py-2 bg-gray-200 flex items-center rounded-md cursor-pointer hover:bg-gray-300">
-              <IconBrandApple
-                className="text-gray-500 mr-2 icon"
-                size={24}
-                strokeWidth={2}
-              />
-              Mac
+              <IconBrandApple className="text-gray-500 mr-2 icon" size={24} strokeWidth={2}/>Mac
             </Tab>
             <Tab className="px-4 py-2 bg-gray-200 flex items-center rounded-md cursor-pointer hover:bg-gray-300">
-              <IconDeviceDesktop
-                className="text-gray-500 mr-2 icon"
-                size={24}
-                strokeWidth={2}
-              />
-              Linux
+              <IconDeviceDesktop className="text-gray-500 mr-2 icon" size={24} strokeWidth={2}/>Linux
             </Tab>
             <Tab className="px-4 py-2 bg-gray-200 flex items-center rounded-md cursor-pointer hover:bg-gray-300">
-              <IconBrandWindows
-                className="text-gray-500 mr-2 icon"
-                size={24}
-                strokeWidth={2}
-              />
-              Windows
+              <IconBrandWindows className="text-gray-500 mr-2 icon" size={24} strokeWidth={2}/>Windows
             </Tab>
           </TabList>
 
           <TabPanel>
             <div className="overflow-x-auto relative">
-              <h1 className="text-xl font-bold leading-tight w-full">
-                Binaries
-              </h1>
+              <h1 className="text-xl font-bold leading-tight w-full">Binaries</h1>
 
               <table className="text-left text-gray-500 mt-6">
                 <thead className="text-xs text-gray-700 uppercase bg-gray-50">
@@ -126,100 +87,46 @@ export default function Downloads({ latestVersion, releaseDate }) {
                 </thead>
                 <tbody>
                   <tr className="bg-white border-b">
-                    <td
-                      scope="row"
-                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
-                    >
-                      <IconBrandApple
-                        className="text-gray-500"
-                        size={24}
-                        strokeWidth={2}
-                      />
-                      <span className="label ml-2">Mac x64</span>
+                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
+                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac x64</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                      <a
-                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.dmg`}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="link"
-                      >
-                        Download
-                      </a>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.dmg`} target="_blank" rel="noreferrer" className='link'>
+                      Download
+                    </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td
-                      scope="row"
-                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
-                    >
-                      <IconBrandApple
-                        className="text-gray-500"
-                        size={24}
-                        strokeWidth={2}
-                      />
-                      <span className="label ml-2">Mac x64 (Portable)</span>
+                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
+                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac x64 (Portable)</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                      <a
-                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.zip`}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="link"
-                      >
-                        Download
-                      </a>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.zip`} target="_blank" rel="noreferrer" className='link'>
+                      Download
+                    </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td
-                      scope="row"
-                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
-                    >
-                      <IconBrandApple
-                        className="text-gray-500"
-                        size={24}
-                        strokeWidth={2}
-                      />
-                      <span className="label ml-2">Mac Apple Silicon</span>
+                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
+                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac Apple Silicon</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                      <a
-                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.dmg`}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="link"
-                      >
-                        Download
-                      </a>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.dmg`} target="_blank" rel="noreferrer" className='link'>
+                      Download
+                    </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td
-                      scope="row"
-                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
-                    >
-                      <IconBrandApple
-                        className="text-gray-500"
-                        size={24}
-                        strokeWidth={2}
-                      />
-                      <span className="label ml-2">
-                        Mac Apple Silicon (Portable)
-                      </span>
+                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
+                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac Apple Silicon (Portable)</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                      <a
-                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.zip`}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="link"
-                      >
-                        Download
-                      </a>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.zip`} target="_blank" rel="noreferrer" className='link'>
+                      Download
+                    </a>
                     </td>
                   </tr>
                 </tbody>
@@ -227,26 +134,17 @@ export default function Downloads({ latestVersion, releaseDate }) {
             </div>
 
             <div className="mt-6">
-              <h1 className="text-xl font-bold leading-tight w-full">
-                Homebrew
-              </h1>
+              <h1 className="text-xl font-bold leading-tight w-full">Homebrew</h1>
               <p className="text-gray-500 mt-2">
                 To install via Homebrew, run the following command:
               </p>
-              <code
-                style={{ fontSize: 14 }}
-                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
-              >
-                brew install bruno
-              </code>
+              <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">brew install bruno</code>
             </div>
           </TabPanel>
 
           <TabPanel>
             <div className="overflow-x-auto relative">
-              <h1 className="text-xl font-bold leading-tight w-full">
-                Binaries
-              </h1>
+              <h1 className="text-xl font-bold leading-tight w-full">Binaries</h1>
               <table className="text-left text-gray-500 mt-6">
                 <thead className="text-xs text-gray-700 uppercase bg-gray-50">
                   <tr>
@@ -260,50 +158,24 @@ export default function Downloads({ latestVersion, releaseDate }) {
                 </thead>
                 <tbody>
                   <tr className="bg-white border-b">
-                    <td
-                      scope="row"
-                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
-                    >
-                      <IconBrandUbuntu
-                        className="text-gray-500"
-                        size={24}
-                        strokeWidth={2}
-                      />
-                      <span className="label ml-2">Ubuntu / Debian</span>
+                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
+                      <IconBrandUbuntu className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Ubuntu / Debian</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                      <a
-                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_amd64_linux.deb`}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="link"
-                      >
-                        Download
-                      </a>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_amd64_linux.deb`} target="_blank" rel="noreferrer" className='link'>
+                      Download
+                    </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td
-                      scope="row"
-                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
-                    >
-                      <IconDeviceDesktop
-                        className="text-gray-500"
-                        size={24}
-                        strokeWidth={2}
-                      />
-                      <span className="label ml-2">Linux AppImage</span>
+                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
+                      <IconDeviceDesktop className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Linux AppImage</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                      <a
-                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x86_64_linux.AppImage`}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="link"
-                      >
-                        Download
-                      </a>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x86_64_linux.AppImage`} target="_blank" rel="noreferrer" className='link'>
+                      Download
+                    </a>
                     </td>
                   </tr>
                 </tbody>
@@ -315,12 +187,7 @@ export default function Downloads({ latestVersion, releaseDate }) {
               <p className="text-gray-500 mt-2">
                 To install via Snap, run the following command:
               </p>
-              <code
-                style={{ fontSize: 14 }}
-                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
-              >
-                snap install bruno
-              </code>
+              <code style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">snap install bruno</code>
             </div>
 
             <div className="mt-6">
@@ -328,16 +195,10 @@ export default function Downloads({ latestVersion, releaseDate }) {
               <p className="text-gray-500 mt-2">
                 To install via Apt, follow these steps:
               </p>
-              <div style={{ width: "fit-content" }}>
+              <div style={{width: "fit-content"}}>
                 <pre
                   className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4"
-                  style={{
-                    fontSize: 14,
-                    width: "fit-content",
-                    whiteSpace: "pre-wrap",
-                    wordWrap: "break-word",
-                    textAlign: "justify",
-                  }}
+                  style={{ fontSize: 14, width: "fit-content",whiteSpace:"pre-wrap",wordWrap:"break-word",textAlign:"justify" }}
                 >
                   sudo mkdir -p /etc/apt/keyrings <br />
                   sudo gpg --no-default-keyring --keyring
@@ -356,9 +217,7 @@ export default function Downloads({ latestVersion, releaseDate }) {
 
           <TabPanel>
             <div className="overflow-x-auto relative">
-              <h1 className="text-xl font-bold leading-tight w-full">
-                Binaries
-              </h1>
+              <h1 className="text-xl font-bold leading-tight w-full">Binaries</h1>
               <table className="text-left text-gray-500 mt-6">
                 <thead className="text-xs text-gray-700 uppercase bg-gray-50">
                   <tr>
@@ -372,69 +231,36 @@ export default function Downloads({ latestVersion, releaseDate }) {
                 </thead>
                 <tbody>
                   <tr className="bg-white border-b">
-                    <td
-                      scope="row"
-                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
-                    >
-                      <IconBrandWindows
-                        className="text-gray-500"
-                        size={24}
-                        strokeWidth={2}
-                      />
-                      <span className="label ml-2">Windows x64</span>
+                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
+                      <IconBrandWindows className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Windows x64</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                      <a
-                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.exe`}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="link"
-                      >
-                        Download
-                      </a>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.exe`} target="_blank" rel="noreferrer" className='link'>
+                      Download
+                    </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td
-                      scope="row"
-                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
-                    >
-                      <IconBrandWindows
-                        className="text-gray-500"
-                        size={24}
-                        strokeWidth={2}
-                      />
-                      <span className="label ml-2">Windows x64 (Portable)</span>
+                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
+                      <IconBrandWindows className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Windows x64 (Portable)</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                      <a
-                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.zip`}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="link"
-                      >
-                        Download
-                      </a>
+                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.zip`} target="_blank" rel="noreferrer" className='link'>
+                      Download
+                    </a>
                     </td>
                   </tr>
                 </tbody>
               </table>
             </div>
 
-            <div className="mt-6">
-              <h1 className="text-xl font-bold leading-tight w-full">
-                Chocolatey
-              </h1>
+        <div className="mt-6">
+              <h1 className="text-xl font-bold leading-tight w-full">Chocolatey</h1>
               <p className="text-gray-500 mt-2">
                 To install via Chocolatey, run the following command:
               </p>
-              <code
-                style={{ fontSize: 14 }}
-                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
-              >
-                choco install bruno
-              </code>
+              <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">choco install bruno</code>
             </div>
 
             <div className="mt-6">
@@ -442,33 +268,16 @@ export default function Downloads({ latestVersion, releaseDate }) {
               <p className="text-gray-500 mt-2">
                 To install via Scoop, run the following commands:
               </p>
-              <code
-                style={{ fontSize: 14 }}
-                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
-              >
-                scoop bucket add extras
-                <br />
-                scoop install bruno
-              </code>
+              <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">scoop bucket add extras<br />scoop install bruno</code>
             </div>
           </TabPanel>
         </Tabs>
 
-        <div className="mt-6">
-          The release notes along with the release and source artifacts can be
-          found under in the{" "}
-          <a
-            href="https://github.com/usebruno/bruno/releases"
-            target="_blank"
-            rel="noreferrer"
-            className="link"
-          >
-            GitHub release
-          </a>
-          .
+        <div className='mt-6'>
+          The release notes along with the release and source artifacts can be found under in the <a href="https://github.com/usebruno/bruno/releases" target="_blank" rel="noreferrer" className='link'>GitHub release</a>.
         </div>
       </main>
-      <Footer />
+      <Footer/>
     </div>
   );
-}
+};

--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -1,30 +1,44 @@
-import Head from 'next/head';
-import Link from 'next/link';
-import { IconBrandApple, IconBrandWindows, IconBrandUbuntu, IconDeviceDesktop } from "@tabler/icons";
-import Navbar from 'components/Navbar';
-import Footer from 'components/Footer';
-import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
-import 'react-tabs/style/react-tabs.css';
-import GlobalStyle from '../globalStyles';
+import Head from "next/head";
+import Link from "next/link";
+import {
+  IconBrandApple,
+  IconBrandWindows,
+  IconBrandUbuntu,
+  IconDeviceDesktop,
+} from "@tabler/icons";
+import Navbar from "components/Navbar";
+import Footer from "components/Footer";
+import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
+import "react-tabs/style/react-tabs.css";
+import GlobalStyle from "../globalStyles";
 
 export async function getStaticProps() {
-  const res = await fetch('https://api.github.com/repos/usebruno/bruno/releases/latest')
-  const data = await res.json()
+  const res = await fetch(
+    "https://api.github.com/repos/usebruno/bruno/releases/latest"
+  );
+  const data = await res.json();
 
   return {
     props: {
-      latestVersion: '1.5.1',
+      latestVersion: "1.5.1",
       // disabling this for now
       // latestVersion: data.tag_name.replace('v', ''),
-      releaseDate: new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(data.created_at)),
+      releaseDate: new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      }).format(new Date(data.created_at)),
     },
-    revalidate: 60*15, // refresh every 15 minutes
-  }
+    revalidate: 60 * 15, // refresh every 15 minutes
+  };
 }
 
 export default function Downloads({ latestVersion, releaseDate }) {
   return (
-    <div className="container flex flex-col root downloads-page" style={{fontFamily: 'Inter', maxWidth: '1024px'}}>
+    <div
+      className="container flex flex-col root downloads-page"
+      style={{ fontFamily: "Inter", maxWidth: "1024px" }}
+    >
       <Head>
         <title>Downloads</title>
         <link rel="icon" href="/favicon.ico" />
@@ -40,13 +54,21 @@ export default function Downloads({ latestVersion, releaseDate }) {
 
         <div className="mt-4">
           <p className="text-gray-500 text-sm">
-            Latest Version: <Link href={`https://github.com/usebruno/bruno/releases/tag/v${latestVersion}`} className='link' target="_blank">{latestVersion}</Link>
+            Latest Version:{" "}
+            <Link
+              href={`https://github.com/usebruno/bruno/releases/tag/v${latestVersion}`}
+              className="link"
+              target="_blank"
+            >
+              {latestVersion}
+            </Link>
           </p>
           <p className="text-gray-500 text-sm">Release Date: {releaseDate}</p>
         </div>
 
-        <div className='mt-4 text-sm'>
-          If you like Bruno and want to support our opensource work, consider sponsoring us via 
+        <div className="mt-4 text-sm">
+          If you like Bruno and want to support our opensource work, consider
+          sponsoring us via
           <a
             href="https://github.com/sponsors/helloanoop"
             target="_blank"
@@ -60,19 +82,36 @@ export default function Downloads({ latestVersion, releaseDate }) {
         <Tabs className="mt-2">
           <TabList className="flex mt-4 space-x-4">
             <Tab className="px-4 py-2 bg-gray-200 flex items-center rounded-md cursor-pointer hover:bg-gray-300">
-              <IconBrandApple className="text-gray-500 mr-2 icon" size={24} strokeWidth={2}/>Mac
+              <IconBrandApple
+                className="text-gray-500 mr-2 icon"
+                size={24}
+                strokeWidth={2}
+              />
+              Mac
             </Tab>
             <Tab className="px-4 py-2 bg-gray-200 flex items-center rounded-md cursor-pointer hover:bg-gray-300">
-              <IconDeviceDesktop className="text-gray-500 mr-2 icon" size={24} strokeWidth={2}/>Linux
+              <IconDeviceDesktop
+                className="text-gray-500 mr-2 icon"
+                size={24}
+                strokeWidth={2}
+              />
+              Linux
             </Tab>
             <Tab className="px-4 py-2 bg-gray-200 flex items-center rounded-md cursor-pointer hover:bg-gray-300">
-              <IconBrandWindows className="text-gray-500 mr-2 icon" size={24} strokeWidth={2}/>Windows
+              <IconBrandWindows
+                className="text-gray-500 mr-2 icon"
+                size={24}
+                strokeWidth={2}
+              />
+              Windows
             </Tab>
           </TabList>
 
           <TabPanel>
             <div className="overflow-x-auto relative">
-              <h1 className="text-xl font-bold leading-tight w-full">Binaries</h1>
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Binaries
+              </h1>
 
               <table className="text-left text-gray-500 mt-6">
                 <thead className="text-xs text-gray-700 uppercase bg-gray-50">
@@ -87,46 +126,100 @@ export default function Downloads({ latestVersion, releaseDate }) {
                 </thead>
                 <tbody>
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac x64</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandApple
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Mac x64</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.dmg`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.dmg`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac x64 (Portable)</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandApple
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Mac x64 (Portable)</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.zip`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.zip`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac Apple Silicon</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandApple
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Mac Apple Silicon</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.dmg`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.dmg`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac Apple Silicon (Portable)</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandApple
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">
+                        Mac Apple Silicon (Portable)
+                      </span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.zip`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.zip`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
                 </tbody>
@@ -134,17 +227,26 @@ export default function Downloads({ latestVersion, releaseDate }) {
             </div>
 
             <div className="mt-6">
-              <h1 className="text-xl font-bold leading-tight w-full">Homebrew</h1>
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Homebrew
+              </h1>
               <p className="text-gray-500 mt-2">
                 To install via Homebrew, run the following command:
               </p>
-              <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">brew install bruno</code>
+              <code
+                style={{ fontSize: 14 }}
+                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
+              >
+                brew install bruno
+              </code>
             </div>
           </TabPanel>
 
           <TabPanel>
             <div className="overflow-x-auto relative">
-              <h1 className="text-xl font-bold leading-tight w-full">Binaries</h1>
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Binaries
+              </h1>
               <table className="text-left text-gray-500 mt-6">
                 <thead className="text-xs text-gray-700 uppercase bg-gray-50">
                   <tr>
@@ -158,24 +260,50 @@ export default function Downloads({ latestVersion, releaseDate }) {
                 </thead>
                 <tbody>
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandUbuntu className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Ubuntu / Debian</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandUbuntu
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Ubuntu / Debian</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_amd64_linux.deb`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_amd64_linux.deb`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconDeviceDesktop className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Linux AppImage</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconDeviceDesktop
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Linux AppImage</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x86_64_linux.AppImage`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x86_64_linux.AppImage`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
                 </tbody>
@@ -187,7 +315,12 @@ export default function Downloads({ latestVersion, releaseDate }) {
               <p className="text-gray-500 mt-2">
                 To install via Snap, run the following command:
               </p>
-              <code style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">snap install bruno</code>
+              <code
+                style={{ fontSize: 14 }}
+                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
+              >
+                snap install bruno
+              </code>
             </div>
 
             <div className="mt-6">
@@ -195,21 +328,37 @@ export default function Downloads({ latestVersion, releaseDate }) {
               <p className="text-gray-500 mt-2">
                 To install via Apt, follow these steps:
               </p>
-              <pre className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4" style={{fontSize: 14}}>
-                sudo mkdir -p /etc/apt/keyrings <br />
-                sudo gpg --no-default-keyring --keyring /etc/apt/keyrings/bruno.gpg --keyserver keyserver.ubuntu.com --recv-keys 9FA6017ECABE0266 <br /><br />
-
-                echo "deb [signed-by=/etc/apt/keyrings/bruno.gpg] http://debian.usebruno.com/ bruno stable" | sudo tee /etc/apt/sources.list.d/bruno.list <br /> <br />
-
-                sudo apt update <br />
-                sudo apt install bruno
-              </pre>
+              <div style={{ width: "fit-content" }}>
+                <pre
+                  className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4"
+                  style={{
+                    fontSize: 14,
+                    width: "fit-content",
+                    whiteSpace: "pre-wrap",
+                    wordWrap: "break-word",
+                    textAlign: "justify",
+                  }}
+                >
+                  sudo mkdir -p /etc/apt/keyrings <br />
+                  sudo gpg --no-default-keyring --keyring
+                  /etc/apt/keyrings/bruno.gpg --keyserver keyserver.ubuntu.com
+                  --recv-keys 9FA6017ECABE0266 <br />
+                  <br />
+                  echo "deb [signed-by=/etc/apt/keyrings/bruno.gpg]
+                  http://debian.usebruno.com/ bruno stable" | sudo tee
+                  /etc/apt/sources.list.d/bruno.list <br /> <br />
+                  sudo apt update <br />
+                  sudo apt install bruno
+                </pre>
+              </div>
             </div>
           </TabPanel>
 
           <TabPanel>
             <div className="overflow-x-auto relative">
-              <h1 className="text-xl font-bold leading-tight w-full">Binaries</h1>
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Binaries
+              </h1>
               <table className="text-left text-gray-500 mt-6">
                 <thead className="text-xs text-gray-700 uppercase bg-gray-50">
                   <tr>
@@ -223,36 +372,69 @@ export default function Downloads({ latestVersion, releaseDate }) {
                 </thead>
                 <tbody>
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandWindows className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Windows x64</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandWindows
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Windows x64</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.exe`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.exe`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandWindows className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Windows x64 (Portable)</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandWindows
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Windows x64 (Portable)</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.zip`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.zip`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
                 </tbody>
               </table>
             </div>
 
-        <div className="mt-6">
-              <h1 className="text-xl font-bold leading-tight w-full">Chocolatey</h1>
+            <div className="mt-6">
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Chocolatey
+              </h1>
               <p className="text-gray-500 mt-2">
                 To install via Chocolatey, run the following command:
               </p>
-              <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">choco install bruno</code>
+              <code
+                style={{ fontSize: 14 }}
+                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
+              >
+                choco install bruno
+              </code>
             </div>
 
             <div className="mt-6">
@@ -260,16 +442,33 @@ export default function Downloads({ latestVersion, releaseDate }) {
               <p className="text-gray-500 mt-2">
                 To install via Scoop, run the following commands:
               </p>
-              <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">scoop bucket add extras<br />scoop install bruno</code>
+              <code
+                style={{ fontSize: 14 }}
+                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
+              >
+                scoop bucket add extras
+                <br />
+                scoop install bruno
+              </code>
             </div>
           </TabPanel>
         </Tabs>
 
-        <div className='mt-6'>
-          The release notes along with the release and source artifacts can be found under in the <a href="https://github.com/usebruno/bruno/releases" target="_blank" rel="noreferrer" className='link'>GitHub release</a>.
+        <div className="mt-6">
+          The release notes along with the release and source artifacts can be
+          found under in the{" "}
+          <a
+            href="https://github.com/usebruno/bruno/releases"
+            target="_blank"
+            rel="noreferrer"
+            className="link"
+          >
+            GitHub release
+          </a>
+          .
         </div>
       </main>
-      <Footer/>
+      <Footer />
     </div>
   );
-};
+}


### PR DESCRIPTION
<h1>Before</h1>

![image](https://github.com/usebruno/bruno-website/assets/85920362/99fcb6b0-2c80-4861-b01e-47de20c46e83)

<h1>After</h1>

![image](https://github.com/usebruno/bruno-website/assets/85920362/feff0b2f-f08f-401e-8ec4-6f59d38cbd6b)

Adjusted CSS styles and layout properties to ensure responsiveness for the Apt installation steps on the Downloads page (https://bruno-website.vercel.app/downloads). The changes ensure a consistent and user-friendly experience across various devices and screen sizes, resolving the issue-No:https://github.com/usebruno/bruno-website/issues/29  where the installation steps were not displaying correctly