### PR TITLE
Add arch to source list file

### DIFF
--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -211,7 +211,7 @@ export default function Downloads({ latestVersion, releaseDate }) {
                   /etc/apt/keyrings/bruno.gpg --keyserver keyserver.ubuntu.com
                   --recv-keys 9FA6017ECABE0266 <br />
                   <br />
-                  echo "deb [signed-by=/etc/apt/keyrings/bruno.gpg]
+                  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/bruno.gpg]
                   http://debian.usebruno.com/ bruno stable" | sudo tee
                   /etc/apt/sources.list.d/bruno.list <br /> <br />
                   sudo apt update <br />


### PR DESCRIPTION
Without the `arch` arg added to the source list I was getting the following warning running `apt update`:

```console
N: Skipping acquisition of configured file 'stable/binary-i386/Packages', as repository 'http://debian.usebruno.com bruno InRelease' doesn't support architecture 'i386'
```

This PR adds the arch arg using the result of `dpkg --print-architecture`