### PR TITLE
fix: center contributors image

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -57,7 +57,7 @@ export default function About() {
               <img
                 src="https://contrib.rocks/image?repo=usebruno/bruno"
                 alt="Contributors"
-                className="cursor-pointer"
+                className="mx-auto my-0 cursor-pointer"
                 onClick={() => window.open("https://github.com/usebruno/bruno/graphs/contributors")}
               />
             </div>


### PR DESCRIPTION
Hi, 

Here's what's changing in a more visual way:

<details>
  <summary>Mobile</summary>

Old:

![image](https://github.com/usebruno/bruno-website/assets/1509413/4aa8dc65-03ba-4346-a214-70f95e081ab4)


New:

![image](https://github.com/usebruno/bruno-website/assets/1509413/98994f0f-8531-4695-97b8-6f9abccddfef)

</details>


<details>
  <summary>Desktop</summary>

Old:

![image](https://github.com/usebruno/bruno-website/assets/1509413/649c7d07-eca0-444c-ba37-cc2b97935dc4)


New:

![image](https://github.com/usebruno/bruno-website/assets/1509413/a2b8e978-e656-4410-b2c2-b4c9b6c08ab5)

</details>

I hope this helps.

Best,
G.