### PR TITLE
Download via Flatpak

### DIFF
--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -1,31 +1,45 @@
-import Bruno from 'components/Bruno';
-import Head from 'next/head';
-import Link from 'next/link';
-import { IconBrandApple, IconBrandWindows, IconBrandUbuntu, IconDeviceDesktop } from "@tabler/icons";
-import Navbar from 'components/Navbar';
-import Footer from 'components/Footer';
-import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
-import 'react-tabs/style/react-tabs.css';
-import GlobalStyle from '../globalStyles';
+import Bruno from "components/Bruno";
+import Head from "next/head";
+import Link from "next/link";
+import {
+  IconBrandApple,
+  IconBrandWindows,
+  IconBrandUbuntu,
+  IconDeviceDesktop,
+} from "@tabler/icons";
+import Navbar from "components/Navbar";
+import Footer from "components/Footer";
+import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
+import "react-tabs/style/react-tabs.css";
+import GlobalStyle from "../globalStyles";
 
 export async function getStaticProps() {
-  const res = await fetch('https://api.github.com/repos/usebruno/bruno/releases/latest')
-  const data = await res.json()
+  const res = await fetch(
+    "https://api.github.com/repos/usebruno/bruno/releases/latest"
+  );
+  const data = await res.json();
 
   return {
     props: {
-      latestVersion: '1.9.0',
+      latestVersion: "1.9.0",
       // disabling this for now
       // latestVersion: data.tag_name.replace('v', ''),
-      releaseDate: new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(data.created_at)),
+      releaseDate: new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      }).format(new Date(data.created_at)),
     },
-    revalidate: 60*15, // refresh every 15 minutes
-  }
+    revalidate: 60 * 15, // refresh every 15 minutes
+  };
 }
 
 export default function Downloads({ latestVersion, releaseDate }) {
   return (
-    <div className="container flex flex-col root downloads-page" style={{fontFamily: 'Inter', maxWidth: '1280px'}}>
+    <div
+      className="container flex flex-col root downloads-page"
+      style={{ fontFamily: "Inter", maxWidth: "1280px" }}
+    >
       <Head>
         <title>Downloads</title>
         <link rel="icon" href="/favicon.ico" />
@@ -41,7 +55,14 @@ export default function Downloads({ latestVersion, releaseDate }) {
 
         <div className="mt-4">
           <p className="text-gray-500 text-sm">
-            Latest Version: <Link href={`https://github.com/usebruno/bruno/releases/tag/v${latestVersion}`} className='link' target="_blank">{latestVersion}</Link>
+            Latest Version:{" "}
+            <Link
+              href={`https://github.com/usebruno/bruno/releases/tag/v${latestVersion}`}
+              className="link"
+              target="_blank"
+            >
+              {latestVersion}
+            </Link>
           </p>
           <p className="text-gray-500 text-sm">Release Date: {releaseDate}</p>
         </div>
@@ -50,15 +71,19 @@ export default function Downloads({ latestVersion, releaseDate }) {
           className="mt-4 border inline-flex flex py-2 px-4 rounded-lg text-sm"
           style={{ maxWidth: "max-content" }}
         >
-          <div className='flex'>
-            <Bruno width={45}/>
+          <div className="flex">
+            <Bruno width={45} />
           </div>
           <div className="ml-3 flex flex-col">
             <p>
-              Golden Edition Pre-Orders available at <span className="line-through">$19</span> <span className="text-yellow-600 text-lg ">$9</span> !
+              Golden Edition Pre-Orders available at{" "}
+              <span className="line-through">$19</span>{" "}
+              <span className="text-yellow-600 text-lg ">$9</span> !
             </p>
             <p>
-              <a href="/buy-golden-edition" className="link">Pre-Order Now!</a>
+              <a href="/buy-golden-edition" className="link">
+                Pre-Order Now!
+              </a>
             </p>
           </div>
         </div>
@@ -66,19 +91,36 @@ export default function Downloads({ latestVersion, releaseDate }) {
         <Tabs className="mt-2">
           <TabList className="flex mt-4 space-x-4">
             <Tab className="px-4 py-2 bg-gray-200 flex items-center rounded-md cursor-pointer hover:bg-gray-300">
-              <IconBrandApple className="text-gray-500 mr-2 icon" size={24} strokeWidth={2}/>Mac
+              <IconBrandApple
+                className="text-gray-500 mr-2 icon"
+                size={24}
+                strokeWidth={2}
+              />
+              Mac
             </Tab>
             <Tab className="px-4 py-2 bg-gray-200 flex items-center rounded-md cursor-pointer hover:bg-gray-300">
-              <IconDeviceDesktop className="text-gray-500 mr-2 icon" size={24} strokeWidth={2}/>Linux
+              <IconDeviceDesktop
+                className="text-gray-500 mr-2 icon"
+                size={24}
+                strokeWidth={2}
+              />
+              Linux
             </Tab>
             <Tab className="px-4 py-2 bg-gray-200 flex items-center rounded-md cursor-pointer hover:bg-gray-300">
-              <IconBrandWindows className="text-gray-500 mr-2 icon" size={24} strokeWidth={2}/>Windows
+              <IconBrandWindows
+                className="text-gray-500 mr-2 icon"
+                size={24}
+                strokeWidth={2}
+              />
+              Windows
             </Tab>
           </TabList>
 
           <TabPanel>
             <div className="overflow-x-auto relative">
-              <h1 className="text-xl font-bold leading-tight w-full">Binaries</h1>
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Binaries
+              </h1>
 
               <table className="text-left text-gray-500 mt-6">
                 <thead className="text-xs text-gray-700 uppercase bg-gray-50">
@@ -93,46 +135,100 @@ export default function Downloads({ latestVersion, releaseDate }) {
                 </thead>
                 <tbody>
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac x64</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandApple
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Mac x64</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.dmg`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.dmg`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac x64 (Portable)</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandApple
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Mac x64 (Portable)</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.zip`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_mac.zip`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac Apple Silicon</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandApple
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Mac Apple Silicon</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.dmg`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.dmg`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandApple className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Mac Apple Silicon (Portable)</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandApple
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">
+                        Mac Apple Silicon (Portable)
+                      </span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.zip`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_arm64_mac.zip`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
                 </tbody>
@@ -140,17 +236,26 @@ export default function Downloads({ latestVersion, releaseDate }) {
             </div>
 
             <div className="mt-6">
-              <h1 className="text-xl font-bold leading-tight w-full">Homebrew</h1>
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Homebrew
+              </h1>
               <p className="text-gray-500 mt-2">
                 To install via Homebrew, run the following command:
               </p>
-              <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">brew install bruno</code>
+              <code
+                style={{ fontSize: 14 }}
+                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
+              >
+                brew install bruno
+              </code>
             </div>
           </TabPanel>
 
           <TabPanel>
             <div className="overflow-x-auto relative">
-              <h1 className="text-xl font-bold leading-tight w-full">Binaries</h1>
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Binaries
+              </h1>
               <table className="text-left text-gray-500 mt-6">
                 <thead className="text-xs text-gray-700 uppercase bg-gray-50">
                   <tr>
@@ -164,28 +269,69 @@ export default function Downloads({ latestVersion, releaseDate }) {
                 </thead>
                 <tbody>
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandUbuntu className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Ubuntu / Debian</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandUbuntu
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Ubuntu / Debian</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_amd64_linux.deb`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_amd64_linux.deb`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconDeviceDesktop className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Linux AppImage</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconDeviceDesktop
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Linux AppImage</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x86_64_linux.AppImage`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x86_64_linux.AppImage`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
                 </tbody>
               </table>
+            </div>
+
+            <div className="mt-6">
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Flatpak
+              </h1>
+              <p className="text-gray-500 mt-2">
+                To install via Flatpak, run the following command:
+              </p>
+              <code
+                style={{ fontSize: 14 }}
+                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
+              >
+                flatpak install com.usebruno.Bruno
+              </code>
             </div>
 
             <div className="mt-6">
@@ -193,7 +339,12 @@ export default function Downloads({ latestVersion, releaseDate }) {
               <p className="text-gray-500 mt-2">
                 To install via Snap, run the following command:
               </p>
-              <code style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">snap install bruno</code>
+              <code
+                style={{ fontSize: 14 }}
+                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
+              >
+                snap install bruno
+              </code>
             </div>
 
             <div className="mt-6">
@@ -201,10 +352,16 @@ export default function Downloads({ latestVersion, releaseDate }) {
               <p className="text-gray-500 mt-2">
                 To install via Apt, follow these steps:
               </p>
-              <div style={{width: "fit-content"}}>
+              <div style={{ width: "fit-content" }}>
                 <pre
                   className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4"
-                  style={{ fontSize: 14, width: "fit-content",whiteSpace:"pre-wrap",wordWrap:"break-word",textAlign:"justify" }}
+                  style={{
+                    fontSize: 14,
+                    width: "fit-content",
+                    whiteSpace: "pre-wrap",
+                    wordWrap: "break-word",
+                    textAlign: "justify",
+                  }}
                 >
                   sudo mkdir -p /etc/apt/keyrings <br />
                   sudo gpg --no-default-keyring --keyring
@@ -223,7 +380,9 @@ export default function Downloads({ latestVersion, releaseDate }) {
 
           <TabPanel>
             <div className="overflow-x-auto relative">
-              <h1 className="text-xl font-bold leading-tight w-full">Binaries</h1>
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Binaries
+              </h1>
               <table className="text-left text-gray-500 mt-6">
                 <thead className="text-xs text-gray-700 uppercase bg-gray-50">
                   <tr>
@@ -237,36 +396,69 @@ export default function Downloads({ latestVersion, releaseDate }) {
                 </thead>
                 <tbody>
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandWindows className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Windows x64</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandWindows
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Windows x64</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.exe`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.exe`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
 
                   <tr className="bg-white border-b">
-                    <td scope="row" className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap">
-                      <IconBrandWindows className="text-gray-500" size={24} strokeWidth={2}/><span className="label ml-2">Windows x64 (Portable)</span>
+                    <td
+                      scope="row"
+                      className="py-2 pl-6 pr-10 flex items-center font-medium text-gray-900 whitespace-nowrap"
+                    >
+                      <IconBrandWindows
+                        className="text-gray-500"
+                        size={24}
+                        strokeWidth={2}
+                      />
+                      <span className="label ml-2">Windows x64 (Portable)</span>
                     </td>
                     <td className="py-3 pl-6 pr-10">
-                    <a href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.zip`} target="_blank" rel="noreferrer" className='link'>
-                      Download
-                    </a>
+                      <a
+                        href={`https://github.com/usebruno/bruno/releases/download/v${latestVersion}/bruno_${latestVersion}_x64_win.zip`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link"
+                      >
+                        Download
+                      </a>
                     </td>
                   </tr>
                 </tbody>
               </table>
             </div>
 
-        <div className="mt-6">
-              <h1 className="text-xl font-bold leading-tight w-full">Chocolatey</h1>
+            <div className="mt-6">
+              <h1 className="text-xl font-bold leading-tight w-full">
+                Chocolatey
+              </h1>
               <p className="text-gray-500 mt-2">
                 To install via Chocolatey, run the following command:
               </p>
-              <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">choco install bruno</code>
+              <code
+                style={{ fontSize: 14 }}
+                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
+              >
+                choco install bruno
+              </code>
             </div>
 
             <div className="mt-6">
@@ -274,16 +466,33 @@ export default function Downloads({ latestVersion, releaseDate }) {
               <p className="text-gray-500 mt-2">
                 To install via Scoop, run the following commands:
               </p>
-              <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">scoop bucket add extras<br />scoop install bruno</code>
+              <code
+                style={{ fontSize: 14 }}
+                className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block"
+              >
+                scoop bucket add extras
+                <br />
+                scoop install bruno
+              </code>
             </div>
           </TabPanel>
         </Tabs>
 
-        <div className='mt-6'>
-          The release notes along with the release and source artifacts can be found under in the <a href="https://github.com/usebruno/bruno/releases" target="_blank" rel="noreferrer" className='link'>GitHub release</a>.
+        <div className="mt-6">
+          The release notes along with the release and source artifacts can be
+          found under in the{" "}
+          <a
+            href="https://github.com/usebruno/bruno/releases"
+            target="_blank"
+            rel="noreferrer"
+            className="link"
+          >
+            GitHub release
+          </a>
+          .
         </div>
       </main>
-      <Footer/>
+      <Footer />
     </div>
   );
-};
+}


### PR DESCRIPTION
I noticed that the [project's GitHub repository mentions a Flatpak version avaiable](https://github.com/usebruno/bruno#installation), but it's not listed on the Linux download page.

I placed it before Snap because it's a "more generic version" and it's included by default in various Linux distributions.




