### PR TITLE
Update downloads.js

### DIFF
--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -211,7 +211,7 @@ export default function Downloads({ latestVersion, releaseDate }) {
                   /etc/apt/keyrings/bruno.gpg --keyserver keyserver.ubuntu.com
                   --recv-keys 9FA6017ECABE0266 <br />
                   <br />
-                  echo "deb [signed-by=/etc/apt/keyrings/bruno.gpg]
+                  echo "deb [signed-by=/etc/apt/keyrings/bruno.gpg arch=amd64]
                   http://debian.usebruno.com/ bruno stable" | sudo tee
                   /etc/apt/sources.list.d/bruno.list <br /> <br />
                   sudo apt update <br />


### PR DESCRIPTION
Avoids the following notice when installing on a system with multiarch enabled: `N: Skipping acquire of configured file 'stable/binary-i386/Packages' as repository 'http://debian.usebruno.com bruno InRelease' doesn't support architecture 'i386'`