### PR TITLE
Add WinGet installation instructions to Windows tab of download page

### DIFF
--- a/src/pages/downloads.js
+++ b/src/pages/downloads.js
@@ -296,7 +296,7 @@ export default function Downloads({ latestVersion, releaseDate }) {
               </table>
             </div>
 
-        <div className="mt-6">
+            <div className="mt-6">
               <h1 className="text-xl font-bold leading-tight w-full">Chocolatey</h1>
               <p className="text-gray-500 mt-2">
                 To install via Chocolatey, run the following command:
@@ -310,6 +310,14 @@ export default function Downloads({ latestVersion, releaseDate }) {
                 To install via Scoop, run the following commands:
               </p>
               <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">scoop bucket add extras<br />scoop install bruno</code>
+            </div>
+            
+            <div className="mt-6">
+              <h1 className="text-xl font-bold leading-tight w-full">WinGet</h1>
+              <p className="text-gray-500 mt-2">
+                To install via WinGet, run the following commands:
+              </p>
+              <code  style={{fontSize: 14}} className="bg-gray-100 text-gray-700 rounded px-4 py-2 mt-4 inline-block">winget install Bruno.Bruno</code>
             </div>
           </TabPanel>
         </Tabs>


### PR DESCRIPTION
## Issue

winget installation is listed in the [readme](https://github.com/usebruno/bruno/blob/7e305be817b5c7db24fc590c9eb2a567c6b27e22/readme.md?plain=1#L69-L70); however, it was not included in the installation instructions on the Download page

## Solution

- Add winget installation instructions to download page
- Fix indentation of leading div