### PR TITLE
fix: increment header z-index to show above everything else

### DIFF
--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -41,7 +41,7 @@ const Navbar = () => {
   };
 
   return (
-    <StyledWrapper className="w-full site-navbar sticky top-0 z-10">
+    <StyledWrapper className="w-full site-navbar sticky top-0 z-20">
       <div>
         <header className="flex items-center justify-between py-4">
           <div>


### PR DESCRIPTION
fixes: #67

# Description
On the pricing page the header goes behind some text elements when scrolling.
Increasing the z-index value from 10 to 20 for the containing element fixes the issue

## Contribution Checklist:

- [x] The pull request only addresses one issue or adds one feature.
- [x] The pull request does not introduce any breaking changes
- [x] I have added screenshots or gifs to help explain the change if applicable.
- [x] I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).
- [x] Create an issue and link to the pull request.

### Before
![bruno-before](https://github.com/user-attachments/assets/5801127e-2483-41ea-8d0c-49be0b113050)

### After
![bruno-after](https://github.com/user-attachments/assets/c646baab-3bc4-41ba-9c23-095b3d5e361c)
